### PR TITLE
Fixed incorrect NSURL method call

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: py-applescript
-Version: 1.0.0
+Version: 1.0.1
 Summary: An easy-to-use Python wrapper for NSAppleScript, allowing Python scripts to communicate with AppleScripts and AppleScriptable applications.
 Home-page: UNKNOWN
 Author: UNKNOWN

--- a/applescript/__init__.py
+++ b/applescript/__init__.py
@@ -35,7 +35,7 @@ class AppleScript:
 			- If the script cannot be read/compiled, a ScriptError is raised.
 		"""
 		if path:
-			url = NSURL.URLWithFilePath_(path)
+			url = NSURL.fileURLWithPath_(path)
 			self._script, errorinfo = NSAppleScript.alloc().initWithContentsOfURL_error_(url, None)
 			if errorinfo:
 				raise ScriptError(errorinfo)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
 		name = "py-applescript",
-		version = "1.0.0",
+		version = "1.0.1",
 		description = "An easy-to-use Python wrapper for NSAppleScript, allowing Python scripts to communicate with AppleScripts and AppleScriptable applications.",
 		platforms = ['Mac OS X'],
 		license = 'Public Domain',


### PR DESCRIPTION
NSURL.URLWitheFilePath doesn’t exist so you can’t load an AppleScript
from a file. The correct call is NSURL.fileURLWithPath. Also bumped the
version number to 1.0.1. I’ll leave it up to the original repo owner to
push it up to pypi.